### PR TITLE
Fix: never show x1 multiplication on medium/hard

### DIFF
--- a/math.js
+++ b/math.js
@@ -41,8 +41,9 @@ export function generateProblem(mode, activeOps) {
     correctAnswer = a - b;
     text = `${a} − ${b} = ?`;
   } else {
-    a = rand(1, r.mul);
-    b = rand(1, r.mul);
+    const mulMin = mode === 'easy' ? 1 : 2;
+    a = rand(mulMin, r.mul);
+    b = rand(mulMin, r.mul);
     correctAnswer = a * b;
     text = `${a} × ${b} = ?`;
   }

--- a/math.test.js
+++ b/math.test.js
@@ -91,6 +91,32 @@ describe('generateProblem', () => {
     }
   });
 
+  it('never produces x1 multiplication on medium', () => {
+    for (let i = 0; i < 200; i++) {
+      const p = generateProblem('medium', ['×']);
+      assert.ok(p.a >= 2, `medium: a was ${p.a}`);
+      assert.ok(p.b >= 2, `medium: b was ${p.b}`);
+    }
+  });
+
+  it('never produces x1 multiplication on hard', () => {
+    for (let i = 0; i < 200; i++) {
+      const p = generateProblem('hard', ['×']);
+      assert.ok(p.a >= 2, `hard: a was ${p.a}`);
+      assert.ok(p.b >= 2, `hard: b was ${p.b}`);
+    }
+  });
+
+  it('allows x1 multiplication on easy', () => {
+    // Run enough times that we'd expect to see a 1 if it's possible
+    let sawOne = false;
+    for (let i = 0; i < 500; i++) {
+      const p = generateProblem('easy', ['×']);
+      if (p.a === 1 || p.b === 1) { sawOne = true; break; }
+    }
+    assert.ok(sawOne, 'easy mode should allow 1 as a multiplication operand');
+  });
+
   it('returns a text property with = ?', () => {
     const p = generateProblem('easy', ['+']);
     assert.ok(p.text.endsWith('= ?'));


### PR DESCRIPTION
## Summary
- Multiplication operands now start at 2 (instead of 1) for medium and hard difficulty levels
- Easy mode is unchanged and can still show x1

Closes #1

## Test plan
- [x] Added tests verifying medium/hard never produce operands of 1
- [x] Added test confirming easy mode still allows 1
- [x] All 21 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)