### PR TITLE
Fix: prevent native keyboard on mobile devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -259,7 +259,7 @@
     <div class="stars" id="stars"></div>
 
     <div class="input-row">
-      <input id="answer" type="number" inputmode="numeric" autocomplete="off" />
+      <input id="answer" type="text" readonly autocomplete="off" />
       <button class="btn-check" id="checkBtn">GO</button>
     </div>
 


### PR DESCRIPTION
## Summary
- Set `readonly` on the answer input to prevent native keyboard from popping up on mobile/tablet
- Changed input type from `number` to `text` to avoid spinner arrows on readonly inputs
- Custom numpad already handles all input, so no functionality is lost

Closes #2

## Test plan
- [ ] Verify on mobile/tablet that native keyboard no longer appears
- [ ] Verify custom numpad still works (digits, backspace, clear, negative, GO)
- [ ] Verify Enter key still submits on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)